### PR TITLE
Add support for APKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,8 @@ on:
     inputs:
       openwrt_version:
        description: 'OpenWrt version'
-       default: '24.10.0'
+       # Use 25.12-SNAPSHOT for APK and 24.10-SNAPSHOT for IPK
+       default: '25.12-SNAPSHOT'
        required: true
        type: string
   
@@ -16,6 +17,7 @@ jobs:
   build:
     name: ${{ matrix.arch }} build
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         arch:
@@ -42,6 +44,7 @@ jobs:
           ## loongarch64-unknown-linux-musl #
           - loongarch64_generic          # OK
           ## riscv64gc-unknown-linux-musl ###
+          - riscv64_generic              # OK
           - riscv64_riscv64              # OK
           ## x86_64-unknown-linux-musl ######
           - x86_64                       # OK
@@ -65,7 +68,7 @@ jobs:
           - powerpc_8548                 # OK
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -79,11 +82,26 @@ jobs:
       - name: List outputs
         run: |
           find bin/packages
+          
+          # Renaming APK files to include architecture suffix
+          # e.g., librespot_0.8.0-r1.apk -> librespot_0.8.0-r1_aarch64_cortex-a53.apk
+          if ls bin/packages/${{ matrix.arch }}/action/*.apk 1> /dev/null 2>&1; then
+            echo "Processing APK files..."
+            for apk_file in bin/packages/${{ matrix.arch }}/action/*.apk; do
+              filename=$(basename "$apk_file")
+              new_filename="${filename%.apk}_${{ matrix.arch }}.apk"
+              mv bin/packages/${{ matrix.arch }}/action/"$filename" bin/packages/${{ matrix.arch }}/action/"$new_filename"
+            done
+          else
+            echo "No APK files found"
+          fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ls-${{ matrix.arch }}
-          path: bin/packages/${{ matrix.arch }}/action/*.ipk
+          path: |
+            bin/packages/${{ matrix.arch }}/action/*.ipk
+            bin/packages/${{ matrix.arch }}/action/*.apk
 
   release:
 
@@ -93,17 +111,17 @@ jobs:
     
     steps:
     
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
-          path: ipks
+          path: artifacts
           pattern: ls-*
           merge-multiple: true
           
       - name: List outputs
         id: list
         run: |
-          find ipks
-          ls ipks | head -n 1 | awk -F"_" '{ print "usteer-ng_version="$2 }' >> "$GITHUB_OUTPUT"
+          find artifacts
+          ls artifacts | head -n 1 | awk -F"_" '{ print "usteer-ng_version="$2 }' >> "$GITHUB_OUTPUT"
     
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -113,4 +131,4 @@ jobs:
           body: |
             usteer-ng v${{ steps.list.outputs.usteer-ng_version }} OpenWrt ${{ github.event.inputs.openwrt_version }} build
           files: |
-            ipks/*
+            artifacts/*


### PR DESCRIPTION
Update build.yml to enable creation of APKs.

PS: The APK packages are not signed, so you need to install with
`apk add --allow-untrusted usteer-ng-1.0.0-r1_xxx.apk`